### PR TITLE
Make app compatible with k8s 1.16

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2016 - 2018 Giant Swarm GmbH
+   Copyright 2016 - 2019 Giant Swarm GmbH
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/ci-scripts/package.sh
+++ b/ci-scripts/package.sh
@@ -9,7 +9,7 @@ readonly TAG=$2
 readonly VERSION=${TAG:1}
 
 readonly HELM_URL=https://storage.googleapis.com/kubernetes-helm
-readonly HELM_TARBALL=helm-v2.12.0-linux-amd64.tar.gz
+readonly HELM_TARBALL=helm-v2.16.1-linux-amd64.tar.gz
 
 main() {
   if ! setup_helm_client; then

--- a/helm/kubernetes-test-app-chart/Chart.yaml
+++ b/helm/kubernetes-test-app-chart/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: v1.3.1
+appVersion: v1.8.0
 description: A Helm chart for a test app
 name: kubernetes-test-app-chart
 # Depicts the version used for CI. Will get replaced by the version,

--- a/helm/kubernetes-test-app-chart/templates/psp.yaml
+++ b/helm/kubernetes-test-app-chart/templates/psp.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
   name: {{ .Values.name }}

--- a/helm/kubernetes-test-app-chart/values.yaml
+++ b/helm/kubernetes-test-app-chart/values.yaml
@@ -12,7 +12,7 @@ replicas: 1
 image:
   registry: quay.io
   repository: giantswarm/kube-state-metrics
-  tag: v1.3.1
+  tag: v1.8.0
 
 resources:
   limits:
@@ -26,4 +26,4 @@ test:
   image:
     registry: quay.io
     repository: giantswarm/alpine-testing
-    tag: 0.1.0
+    tag: 0.1.1


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/7675

PSP extensions/v1beta1 is no longer served in k8s 1.16, it has been deprecated with policy/v1beta1 in k8s 1.10 (see https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16/)